### PR TITLE
fix : Cleanup pkthandler in libClose

### DIFF
--- a/common/src/cellular_common.c
+++ b/common/src/cellular_common.c
@@ -321,6 +321,7 @@ static void libClose( CellularContext_t * pContext )
         {
             /* Shut down the utilities. */
             _Cellular_PktioShutdown( pContext );
+            _Cellular_PktHandlerCleanup( pContext );
         }
 
         PlatformMutex_Lock( &pContext->libStatusMutex );


### PR DESCRIPTION
* _Cellular_PktHandlerCleanup should be called in libClose to free the resource allocated in _Cellular_PktHandlerInit.